### PR TITLE
Get dicebot to use serenity 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dice-bot"
-version = "0.4.4"
+version = "0.5.0-alpha1"
 authors = ["Lokathor <zefria@gmail.com>"]
 repository = "https://github.com/Lokathor/dice-bot-rs"
 readme = "README.md"
@@ -8,10 +8,11 @@ keywords = ["discord","dice"]
 description = "A discord bot to roll RPG dice rolls."
 license = "0BSD"
 publish = false
+edition = "2018"
 
 [dependencies]
-serenity = "0.5"
-randomize = "1.0"
+serenity = "0.6"
+randomize = "3.0.0-rc.3"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 serenity = "0.6.3"
-randomize = "3.0.0-rc.3"
+randomize = "3.0.0"
 getrandom = "0.1"
 lokacore = "0.2"
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ publish = false
 edition = "2018"
 
 [dependencies]
-serenity = "0.6"
+serenity = "0.6.3"
 randomize = "3.0.0-rc.3"
 getrandom = "0.1"
 lokacore = "0.2"
+lazy_static = "1.4.0"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ edition = "2018"
 [dependencies]
 serenity = "0.6"
 randomize = "3.0.0-rc.3"
+getrandom = "0.1"
+lokacore = "0.2"
 
 [profile.release]
 lto = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,4 @@
 error_on_line_overflow = false
-fn_args_density = "Compressed"
 merge_imports = true
 reorder_imports = true
 use_try_shorthand = true

--- a/src/bin/dicebot.rs
+++ b/src/bin/dicebot.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+//#![feature(const_fn)]
 
 extern crate randomize;
 use randomize::*;
@@ -6,21 +7,24 @@ use randomize::*;
 #[macro_use]
 extern crate serenity;
 use serenity::{
+  client::*,
   framework::standard::*,
+  framework::standard::macros::*,
   model::{
-    channel::{Message, ReactionType},
-    gateway::Ready,
-    id::UserId,
+    channel::*,
+    gateway::*,
+    event::*,
+    id::*,
   },
   prelude::*,
 };
+
+use std::collections::HashSet;
 
 extern crate dice_bot;
 use dice_bot::{earthdawn::*, eote::*, shadowrun::*, *};
 
 use std::process::{Command, Stdio};
-
-pub const LOKATHOR_ID: UserId = UserId(244106113321140224);
 
 pub struct Handler;
 
@@ -36,70 +40,53 @@ fn main() {
     Handler,
   )
   .expect("Could not create the client");
+
+
+  // We will fetch your bot's id.
+  let bot_id = match client.cache_and_http.http.get_current_application_info() {
+      Ok(info) => {
+          info.id
+      },
+      Err(why) => panic!("Could not access application info: {:?}", why),
+  };
+
+  let userid_str = &::std::env::var("USER_ID").expect("Could not obtain USER_ID");
+  let userid : UserId = UserId(userid_str.parse::<u64>().unwrap());
+
   client.with_framework(
     StandardFramework::new()
       .configure(|c| {
         c.allow_dm(true)
-          .allow_whitespace(true)
+          .with_whitespace(WithWhiteSpace { prefixes: true, groups: true, commands: true })
           .ignore_bots(true)
           .ignore_webhooks(true)
-          .on_mention(true)
-          .owners(vec![LOKATHOR_ID].into_iter().collect())
+          .on_mention(Some(bot_id))
+          .owners(vec![userid].into_iter().collect())
           .prefixes(vec![","])
           .no_dm_prefix(true)
           .delimiter(" ")
           .case_insensitivity(true)
       })
-      .simple_bucket("ddate", 60)
-      .simple_bucket("help", 30)
-      .help(help_commands::with_embeds)
-      .command("ddate", |c| c.cmd(ddate).desc("https://en.wikipedia.org/wiki/Discordian_calendar").bucket("ddate"))
-      // Shadowrun
-      .command("sr", |c| c.cmd(shadowrun).desc("Rolls Shadowrun 4e style (up to 10)").usage("DICE [...]"))
-      .command("sre", |c| {
-        c.cmd(shadowrun_edge)
-          .desc("Rolls Shadowrun 4e with 6-again (up to 10)")
-          .usage("DICE [...]")
-      })
-      .command("sra", |c| {
-        c.cmd(shadowrun_attack).desc("Rolls a Shadowrun 4e attack cycle").usage("ATTACK EVADE DAMAGE SOAK")
-      })
-      .command("friend", |c| {
-        c.cmd(shadowrun_friend)
-          .desc("Rolls up a conjured buddy (Spirit / Sprite)")
-          .usage("CONJURE FORCE SOAK")
-      })
-      .command("foe", |c| {
-        c.cmd(shadowrun_foe)
-          .desc("Binds a conjured buddy (Spirit / Sprite)")
-          .usage("BINDING FORCE SOAK")
-      })
-      // Earthdawn
-      .command("ed", |c| {
-        c.cmd(earthdawn).desc("Rolls an Earthdawn 4e step (up to 10)").usage("STEP [...]")
-      })
-      .command("edk", |c| {
-        c.cmd(earthdawn_karma)
-          .desc("Rolls an Earthdawn 4e step with karma (up to 10)")
-          .usage("STEP [...]")
-      })
-      .command("edt", |c| c.cmd(earthdawn_target).desc("Rolls an Earthdawn 4e step").usage("STEP TARGET"))
-      // Other
-      .command("as", |c| c.cmd(after_sundown).desc("Rolls After Sundown style").usage("DICE [...]"))
-      .command("dice", |c| c.cmd(dice).desc("Rolls a standard dice expression").usage("EXPRESSION [...]"))
-      .command("roll", |c| c.cmd(dice).desc("Rolls a standard dice expression").usage("EXPRESSION [...]"))
-      .command("thaco", |c| c.cmd(thaco).desc("Does a THACO attack roll").usage("THACO [...]"))
-      .command("taco", |c| c.cmd(thaco).desc("Does a THACO attack roll").usage("THACO [...]"))
-      .command("eote", |c| c.cmd(eote).desc("Rolls EotE dice (b=black, u=blue)").usage("EXPRESSION [...]"))
-      .command("champ", |c| c.cmd(champions).desc("Rolls a Champions roll").usage("EXPRESSION [...]"))
-      .command("stat2e", |c| c.cmd(stat2e).desc("Rolls a 2e stat array"))
-      // User Commands
-      .command("sigil", |c| c.cmd(sigil_command).desc("It does a mystery thing that Sigil decided upon").usage("BASIC_SUM_STRING [...]"))
+      .bucket("ddate", |b| b.delay(60))
+      .bucket("help", |b| b.delay(30))
+      .help(&MY_HELP)
   );
 
   if let Err(why) = client.start() {
     println!("Client::start error: {:?}", why);
   }
+}
+
+#[help]
+fn my_help(
+    context: &mut Context,
+    msg: &Message,
+    args: Args,
+    help_options: &'static HelpOptions,
+    groups: &[&'static CommandGroup],
+    owners: HashSet<UserId>
+) -> CommandResult {
+    help_commands::with_embeds(context, msg, args, help_options, groups, owners)
 }
 
 /// Opens a child process to check the `ddate` value.
@@ -116,18 +103,26 @@ fn ddate_process() -> Option<String> {
   .ok()
 }
 
-command!(ddate(_ctx, msg, _args) {
+#[command]
+#[description = "https://en.wikipedia.org/wiki/Discordian_calendar"]
+#[bucket = "ddate"]
+fn ddate(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   ddate_process().map(|date| {
-    if let Err(why) = msg.channel_id.say(date) {
+    if let Err(why) = msg.channel_id.say(&_ctx.http, date) {
       println!("Error sending message: {:?}", why);
     }
   });
-});
+  Ok(())
+}
 
-command!(after_sundown(_ctx, msg, args) {
+#[command]
+#[aliases("as")]
+#[description = "Rolls After Sundown style"]
+#[usage = "DICE [...]"]
+fn after_sundown(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
-  for dice_count in args.full().split_whitespace().flat_map(basic_sum_str).take(10) {
+  for dice_count in args.rest().split_whitespace().flat_map(basic_sum_str).take(10) {
     let dice_count = dice_count.max(0).min(5_000) as u32;
     if dice_count > 0 {
       let mut hits = 0;
@@ -153,7 +148,7 @@ command!(after_sundown(_ctx, msg, args) {
       output.push_str(&format!("Rolled {} dice: {} hit{}{}", dice_count, hits, s_for_hits, dice_report_output));
     } else {
       let output = format!("No dice to roll!");
-      if let Err(why) = msg.channel_id.say(output) {
+      if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
         println!("Error sending message: {:?}", why);
       }
     }
@@ -161,16 +156,21 @@ command!(after_sundown(_ctx, msg, args) {
   }
   output.pop();
   if output.len() > 0 {
-    if let Err(why) = msg.channel_id.say(output) {
+    if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
       println!("Error sending message: {:?}", why);
     }
   }
-});
+  Ok(())
+}
 
-command!(dice(_ctx, msg, args) {
+#[command]
+#[aliases("roll", "dice")]
+#[description = "Rolls a standard dice expression"]
+#[usage = "EXPRESSION [...]"]
+fn dice(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
-  'exprloop: for dice_expression_str in args.full().split_whitespace().take(20) {
+  'exprloop: for dice_expression_str in args.rest().split_whitespace().take(20) {
     let mut plus_only_form = dice_expression_str.replace("-","+-");
     let mut total: i32 = 0;
     let mut sub_expressions = vec![];
@@ -229,7 +229,7 @@ command!(dice(_ctx, msg, args) {
           10 => d10,
           12 => d12,
           20 => d20,
-          _ => RandRangeU32::new(1..=num_sides)
+          _ => RandRangeU32::new(1, num_sides)
         };
         if num_dice > 0 {
           for _ in 0 .. num_dice {
@@ -262,35 +262,45 @@ command!(dice(_ctx, msg, args) {
   }
   output.pop();
   if output.len() > 0 {
-    if let Err(why) = msg.channel_id.say(output) {
+    if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
       println!("Error sending message: {:?}", why);
     }
   }
-});
+  Ok(())
+}
 
-command!(thaco(_ctx, msg, args) {
+#[command]
+#[description = "Does a THACO attack roll"]
+#[usage = "THACO [...]"]
+#[aliases("thaco", "taco")]
+fn thaco(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
-  for thaco_value in args.full().split_whitespace().flat_map(basic_sum_str).take(20) {
+  for thaco_value in args.rest().split_whitespace().flat_map(basic_sum_str).take(20) {
     let roll = d20.sample(gen) as i32;
     output.push_str(&format!("THACO {}: Rolled {}, Hits AC {} or greater.\n", thaco_value, roll, thaco_value - roll));
   }
   output.pop();
   if output.len() > 0 {
-    if let Err(why) = msg.channel_id.say(output) {
+    if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
       println!("Error sending message: {:?}", why);
     }
   }
-});
+  Ok(())
+}
 
-command!(sigil_command(_ctx, msg, args) {
+#[command]
+#[description = "It does a mystery thing that Sigil decided upon"]
+#[aliases("sigil")]
+#[usage = "BASIC_SUM_STRING [...]"]
+fn sigil_command(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
-  let terms: Vec<i32> = args.full().split_whitespace().filter_map(basic_sum_str).collect();
+  let terms: Vec<i32> = args.rest().split_whitespace().filter_map(basic_sum_str).collect();
   for term in terms {
     let x = term.abs();
     if x > 0 {
-      let mut total = 0;
+      let mut total : i32 = 0;
       for _ in 0 .. x {
         total += d6.sample(gen) as i32;
         total -= d6.sample(gen) as i32;
@@ -302,17 +312,21 @@ command!(sigil_command(_ctx, msg, args) {
   }
   output.pop();
   if output.len() > 0 {
-    if let Err(why) = msg.channel_id.say(output) {
+    if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
       println!("Error sending message: {:?}", why);
     }
   } else {
-    if let Err(why) = msg.channel_id.say("usage: sigil NUMBER") {
+    if let Err(why) = msg.channel_id.say(&_ctx.http, "usage: sigil NUMBER") {
       println!("Error sending message: {:?}", why);
     }
   }
-});
+  Ok(())
+}
 
-command!(stat2e(_ctx, msg, _args) {
+#[command]
+#[description = "Rolls a 2e stat array"]
+#[aliases("stat2e")]
+fn stat2e(_ctx: &mut Context, msg: &Message, _args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
   let roll = |gen: &mut PCG32| {
@@ -325,15 +339,20 @@ command!(stat2e(_ctx, msg, _args) {
   output.push_str(&format!("Wis: {}\n", roll(gen)));
   output.push_str(&format!("Cha: {}\n", roll(gen)));
   output.pop();
-  if let Err(why) = msg.channel_id.say(output) {
+  if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
     println!("Error sending message: {:?}", why);
   }
-});
+  Ok(())
+}
 
-command!(champions(_ctx, msg, args) {
+#[command]
+#[aliases("champ")]
+#[description = "Rolls a Champions roll"]
+#[usage = "EXPRESSION [...]"]
+fn champions(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
-  let terms: Vec<i32> = args.full().split_whitespace().filter_map(basic_sum_str).collect();
+  let terms: Vec<i32> = args.rest().split_whitespace().filter_map(basic_sum_str).collect();
   for term in terms {
     let mut rolls = [0; 3];
     for roll_mut in rolls.iter_mut() {
@@ -350,12 +369,13 @@ command!(champions(_ctx, msg, args) {
   }
   output.pop();
   if output.len() > 0 {
-    if let Err(why) = msg.channel_id.say(output) {
+    if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
       println!("Error sending message: {:?}", why);
     }
   } else {
-    if let Err(why) = msg.channel_id.say("usage: sigil NUMBER") {
+    if let Err(why) = msg.channel_id.say(&_ctx.http, "usage: sigil NUMBER") {
       println!("Error sending message: {:?}", why);
     }
   }
-});
+  Ok(())
+}

--- a/src/bin/dicebot.rs
+++ b/src/bin/dicebot.rs
@@ -1,34 +1,22 @@
 #![allow(unused_imports)]
+#![allow(clippy::write_with_newline)]
+#![allow(clippy::len_zero)]
 //#![feature(const_fn)]
 
-extern crate randomize;
+use dice_bot::{earthdawn::*, eote::*, shadowrun::*, *};
 use randomize::*;
-
-#[macro_use]
-extern crate serenity;
 use serenity::{
-  client::*,
-  client::bridge::gateway::ShardManager,
-  framework::standard::*,
-  framework::standard::macros::*,
-  model::{
-    channel::*,
-    gateway::*,
-    event::*,
-    id::*,
-  },
+  client::{bridge::gateway::ShardManager, *},
+  framework::standard::{macros::*, *},
+  model::{channel::*, event::*, gateway::*, id::*},
   prelude::*,
 };
-
-use std::collections::HashSet;
-use std::sync::Arc;
-use std::collections::HashMap;
-use std::fmt::Write;
-
-extern crate dice_bot;
-use dice_bot::{earthdawn::*, eote::*, shadowrun::*, *};
-
-use std::process::{Command, Stdio};
+use std::{
+  collections::{HashMap, HashSet},
+  fmt::Write,
+  process::{Command, Stdio},
+  sync::Arc,
+};
 
 // A container type is created for inserting into the Client's `data`, which
 // allows for data to be accessible across all events and framework commands, or
@@ -36,13 +24,13 @@ use std::process::{Command, Stdio};
 struct ShardManagerContainer;
 
 impl TypeMapKey for ShardManagerContainer {
-    type Value = Arc<Mutex<ShardManager>>;
+  type Value = Arc<Mutex<ShardManager>>;
 }
 
 struct CommandCounter;
 
 impl TypeMapKey for CommandCounter {
-    type Value = HashMap<String, u64>;
+  type Value = HashMap<String, u64>;
 }
 
 pub struct Handler;
@@ -72,24 +60,25 @@ fn main() {
     data.insert::<ShardManagerContainer>(Arc::clone(&client.shard_manager));
   }
 
-
   // We will fetch your bot's id.
   let bot_id = match client.cache_and_http.http.get_current_application_info() {
-      Ok(info) => {
-          info.id
-      },
-      Err(why) => panic!("Could not access application info: {:?}", why),
+    Ok(info) => info.id,
+    Err(why) => panic!("Could not access application info: {:?}", why),
   };
 
   let userid_str = &::std::env::var("USER_ID").expect("Could not obtain USER_ID");
-  let userid : UserId = UserId(userid_str.parse::<u64>().unwrap());
-  let prefixes = &::std::env::var("PREFIXES").expect()
+  let userid: UserId = UserId(userid_str.parse::<u64>().unwrap());
+  let _prefixes = &::std::env::var("PREFIXES").unwrap_or_else(|_| "".to_string());
 
   client.with_framework(
     StandardFramework::new()
       .configure(|c| {
         c.allow_dm(true)
-          .with_whitespace(WithWhiteSpace { prefixes: true, groups: true, commands: true })
+          .with_whitespace(WithWhiteSpace {
+            prefixes: true,
+            groups: true,
+            commands: true,
+          })
           .ignore_bots(true)
           .ignore_webhooks(true)
           .on_mention(Some(bot_id))
@@ -106,7 +95,7 @@ fn main() {
       .group(&SHADOWRUN_GROUP)
       .group(&EOTE_GROUP)
       .group(&EARTHDAWN_GROUP)
-      .help(&MY_HELP)
+      .help(&MY_HELP),
   );
 
   if let Err(why) = client.start() {
@@ -116,14 +105,14 @@ fn main() {
 
 #[help]
 fn my_help(
-    context: &mut Context,
-    msg: &Message,
-    args: Args,
-    help_options: &'static HelpOptions,
-    groups: &[&'static CommandGroup],
-    owners: HashSet<UserId>
+  context: &mut Context,
+  msg: &Message,
+  args: Args,
+  help_options: &'static HelpOptions,
+  groups: &[&'static CommandGroup],
+  owners: HashSet<UserId>,
 ) -> CommandResult {
-    help_commands::with_embeds(context, msg, args, help_options, groups, owners)
+  help_commands::with_embeds(context, msg, args, help_options, groups, owners)
 }
 
 // Commands can be created via the attribute `#[command]` macro.
@@ -132,20 +121,22 @@ fn my_help(
 // Make this command use the "complicated" bucket.
 #[bucket = "complicated"]
 fn commands(ctx: &mut Context, msg: &Message) -> CommandResult {
-    let mut contents = "Commands used:\n".to_string();
+  let mut contents = "Commands used:\n".to_string();
 
-    let data = ctx.data.read();
-    let counter = data.get::<CommandCounter>().expect("Expected CommandCounter in ShareMap.");
+  let data = ctx.data.read();
+  let counter = data
+    .get::<CommandCounter>()
+    .expect("Expected CommandCounter in ShareMap.");
 
-    for (k, v) in counter {
-        let _ = write!(contents, "- {name}: {amount}\n", name=k, amount=v);
-    }
+  for (k, v) in counter {
+    let _ = write!(contents, "- {name}: {amount}\n", name = k, amount = v);
+  }
 
-    if let Err(why) = msg.channel_id.say(&ctx.http, &contents) {
-        println!("Error sending message: {:?}", why);
-    }
+  if let Err(why) = msg.channel_id.say(&ctx.http, &contents) {
+    println!("Error sending message: {:?}", why);
+  }
 
-    Ok(())
+  Ok(())
 }
 
 /// Opens a child process to check the `ddate` value.
@@ -166,11 +157,11 @@ fn ddate_process() -> Option<String> {
 #[description = "https://en.wikipedia.org/wiki/Discordian_calendar"]
 #[bucket = "ddate"]
 fn ddate(_ctx: &mut Context, msg: &Message, _: Args) -> CommandResult {
-  ddate_process().map(|date| {
+  if let Some(date) = ddate_process() {
     if let Err(why) = msg.channel_id.say(&_ctx.http, date) {
       println!("Error sending message: {:?}", why);
     }
-  });
+  }
   Ok(())
 }
 
@@ -181,20 +172,25 @@ fn ddate(_ctx: &mut Context, msg: &Message, _: Args) -> CommandResult {
 fn after_sundown(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
-  for dice_count in args.rest().split_whitespace().flat_map(basic_sum_str).take(10) {
+  for dice_count in args
+    .rest()
+    .split_whitespace()
+    .flat_map(basic_sum_str)
+    .take(10)
+  {
     let dice_count = dice_count.max(0).min(5_000) as u32;
     if dice_count > 0 {
       let mut hits = 0;
       const DICE_REPORT_MAXIMUM: u32 = 30;
       let mut dice_record = String::with_capacity(DICE_REPORT_MAXIMUM as usize * 2 + 20);
       dice_record.push_str(" `(");
-      for _ in 0 .. dice_count {
+      for _ in 0..dice_count {
         let roll = D6.sample(gen);
         if roll >= 5 {
           hits += 1;
         }
         if dice_count < DICE_REPORT_MAXIMUM {
-          dice_record.push(('0' as u8 + roll as u8) as char);
+          dice_record.push((b'0' + roll as u8) as char);
           dice_record.push(',');
         }
       }
@@ -202,9 +198,16 @@ fn after_sundown(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult
       // I have ABSOLUTELY no idea why we need to put this extra space in here,
       // but we do and that makes the output correct.
       dice_record.push_str(")`");
-      let s_for_hits = if hits != 1 {"s"} else {""};
-      let dice_report_output = if dice_count < DICE_REPORT_MAXIMUM { &dice_record } else { "" };
-      output.push_str(&format!("Rolled {} dice: {} hit{}{}", dice_count, hits, s_for_hits, dice_report_output));
+      let s_for_hits = if hits != 1 { "s" } else { "" };
+      let dice_report_output = if dice_count < DICE_REPORT_MAXIMUM {
+        &dice_record
+      } else {
+        ""
+      };
+      output.push_str(&format!(
+        "Rolled {} dice: {} hit{}{}",
+        dice_count, hits, s_for_hits, dice_report_output
+      ));
     } else {
       let output = format!("No dice to roll!");
       if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
@@ -230,7 +233,7 @@ fn dice(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
   'exprloop: for dice_expression_str in args.rest().split_whitespace().take(20) {
-    let plus_only_form = dice_expression_str.replace("-","+-");
+    let plus_only_form = dice_expression_str.replace("-", "+-");
     let mut total: i32 = 0;
     let mut sub_expressions = vec![];
     for sub_expression in plus_only_form.split('+').take(70) {
@@ -267,9 +270,7 @@ fn dice(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
             }
           }
         }
-        None => {
-          1
-        }
+        None => 1,
       };
       if d_iter.next().is_some() {
         //msg.react(ReactionType::Unicode(EMOJI_QUESTION.to_string())).ok();
@@ -288,15 +289,15 @@ fn dice(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
           10 => D10,
           12 => D12,
           20 => D20,
-          _ => RandRangeU32::new(1, num_sides)
+          _ => RandRangeU32::new(1, num_sides),
         };
         if num_dice > 0 {
-          for _ in 0 .. num_dice {
+          for _ in 0..num_dice {
             total += range.sample(gen) as i32;
           }
           sub_expressions.push(format!("{}d{}", num_dice, num_sides));
         } else if num_dice < 0 {
-          for _ in 0 .. num_dice.abs() {
+          for _ in 0..num_dice.abs() {
             total -= range.sample(gen) as i32;
           }
           sub_expressions.push(format!("{}d{}", num_dice, num_sides));
@@ -314,7 +315,7 @@ fn dice(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
           parsed_string.push_str(&sub_expression);
         }
       }
-      output.push_str(&format!("Rolled {}: {}\n",parsed_string, total));
+      output.push_str(&format!("Rolled {}: {}\n", parsed_string, total));
     } else {
       //msg.react(ReactionType::Unicode(EMOJI_QUESTION.to_string())).ok();
     }
@@ -335,9 +336,19 @@ fn dice(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
 fn thaco(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
-  for thaco_value in args.rest().split_whitespace().flat_map(basic_sum_str).take(20) {
+  for thaco_value in args
+    .rest()
+    .split_whitespace()
+    .flat_map(basic_sum_str)
+    .take(20)
+  {
     let roll = D20.sample(gen) as i32;
-    output.push_str(&format!("THACO {}: Rolled {}, Hits AC {} or greater.\n", thaco_value, roll, thaco_value - roll));
+    output.push_str(&format!(
+      "THACO {}: Rolled {}, Hits AC {} or greater.\n",
+      thaco_value,
+      roll,
+      thaco_value - roll
+    ));
   }
   output.pop();
   if output.len() > 0 {
@@ -355,12 +366,16 @@ fn thaco(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
 fn sigil_command(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
-  let terms: Vec<i32> = args.rest().split_whitespace().filter_map(basic_sum_str).collect();
+  let terms: Vec<i32> = args
+    .rest()
+    .split_whitespace()
+    .filter_map(basic_sum_str)
+    .collect();
   for term in terms {
     let x = term.abs();
     if x > 0 {
-      let mut total : i32 = 0;
-      for _ in 0 .. x {
+      let mut total: i32 = 0;
+      for _ in 0..x {
         total += D6.sample(gen) as i32;
         total -= D6.sample(gen) as i32;
       }
@@ -374,11 +389,10 @@ fn sigil_command(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult
     if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
       println!("Error sending message: {:?}", why);
     }
-  } else {
-    if let Err(why) = msg.channel_id.say(&_ctx.http, "usage: sigil NUMBER") {
-      println!("Error sending message: {:?}", why);
-    }
+  } else if let Err(why) = msg.channel_id.say(&_ctx.http, "usage: sigil NUMBER") {
+    println!("Error sending message: {:?}", why);
   }
+
   Ok(())
 }
 
@@ -388,9 +402,8 @@ fn sigil_command(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult
 fn stat2e(_ctx: &mut Context, msg: &Message, _args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
-  let roll = |gen: &mut PCG32| {
-    4 + D4.sample(gen) + D4.sample(gen) + D4.sample(gen) + D4.sample(gen)
-  };
+  let roll =
+    |gen: &mut PCG32| 4 + D4.sample(gen) + D4.sample(gen) + D4.sample(gen) + D4.sample(gen);
   output.push_str(&format!("Str: {}\n", roll(gen)));
   output.push_str(&format!("Dex: {}\n", roll(gen)));
   output.push_str(&format!("Con: {}\n", roll(gen)));
@@ -411,30 +424,36 @@ fn stat2e(_ctx: &mut Context, msg: &Message, _args: Args) -> CommandResult {
 fn champions(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
-  let terms: Vec<i32> = args.rest().split_whitespace().filter_map(basic_sum_str).collect();
+  let terms: Vec<i32> = args
+    .rest()
+    .split_whitespace()
+    .filter_map(basic_sum_str)
+    .collect();
   for term in terms {
     let mut rolls = [0; 3];
     for roll_mut in rolls.iter_mut() {
       *roll_mut = D6.sample(gen) as i32;
     }
-    output.push_str(&format!("Rolling Champions {}: {}, [{},{},{}]\n",
+    output.push_str(&format!(
+      "Rolling Champions {}: {}, [{},{},{}]\n",
       term,
-      if rolls.iter().cloned().sum::<i32>() < term { "Success" } else { "Failure" },
+      if rolls.iter().cloned().sum::<i32>() < term {
+        "Success"
+      } else {
+        "Failure"
+      },
       rolls[0],
       rolls[1],
       rolls[2]
-      )
-    );
+    ));
   }
   output.pop();
   if output.len() > 0 {
     if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
       println!("Error sending message: {:?}", why);
     }
-  } else {
-    if let Err(why) = msg.channel_id.say(&_ctx.http, "usage: sigil NUMBER") {
-      println!("Error sending message: {:?}", why);
-    }
+  } else if let Err(why) = msg.channel_id.say(&_ctx.http, "usage: sigil NUMBER") {
+    println!("Error sending message: {:?}", why);
   }
   Ok(())
 }

--- a/src/bin/dicebot.rs
+++ b/src/bin/dicebot.rs
@@ -53,6 +53,12 @@ impl EventHandler for Handler {
   }
 }
 
+group!({
+    name: "general",
+    options: {},
+    commands: [commands, ddate, after_sundown, dice, thaco, sigil_command, stat2e, champions]
+});
+
 fn main() {
   let mut client = Client::new(
     &::std::env::var("DISCORD_TOKEN").expect("Could not obtain DISCORD_TOKEN"),
@@ -95,6 +101,10 @@ fn main() {
       .bucket("ddate", |b| b.delay(60))
       .bucket("help", |b| b.delay(30))
       .bucket("complicated", |b| b.delay(5).time_span(30).limit(2))
+      .group(&GENERAL_GROUP)
+      .group(&SHADOWRUN_GROUP)
+      .group(&EOTE_GROUP)
+      .group(&EARTHDAWN_GROUP)
       .help(&MY_HELP)
   );
 

--- a/src/bin/dicebot.rs
+++ b/src/bin/dicebot.rs
@@ -83,6 +83,7 @@ fn main() {
 
   let userid_str = &::std::env::var("USER_ID").expect("Could not obtain USER_ID");
   let userid : UserId = UserId(userid_str.parse::<u64>().unwrap());
+  let prefixes = &::std::env::var("PREFIXES").expect()
 
   client.with_framework(
     StandardFramework::new()
@@ -93,7 +94,7 @@ fn main() {
           .ignore_webhooks(true)
           .on_mention(Some(bot_id))
           .owners(vec![userid].into_iter().collect())
-          .prefixes(vec!["zztop"])
+          .prefixes(vec![","])
           .no_dm_prefix(true)
           .delimiter(" ")
           .case_insensitivity(true)

--- a/src/earthdawn.rs
+++ b/src/earthdawn.rs
@@ -1,11 +1,8 @@
 use super::*;
 use serenity::{
   client::*,
-  framework::standard::*,
-  framework::standard::macros::*,
-  model::{
-    channel::*,
-  },
+  framework::standard::{macros::*, *},
+  model::channel::*,
 };
 
 group!({
@@ -53,7 +50,12 @@ fn earthdawn(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
 
-  for step_value in args.rest().split_whitespace().take(10).filter_map(basic_sum_str) {
+  for step_value in args
+    .rest()
+    .split_whitespace()
+    .take(10)
+    .filter_map(basic_sum_str)
+  {
     let step_roll = step(gen, step_value, false);
     output.push_str(&format!("Rolled step {}: {}\n", step_value, step_roll));
   }
@@ -75,9 +77,17 @@ fn earthdawn_karma(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResu
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
 
-  for step_value in args.rest().split_whitespace().take(10).filter_map(basic_sum_str) {
+  for step_value in args
+    .rest()
+    .split_whitespace()
+    .take(10)
+    .filter_map(basic_sum_str)
+  {
     let step_roll = step(gen, step_value, true);
-    output.push_str(&format!("Rolled step {} with karma: {}\n", step_value, step_roll));
+    output.push_str(&format!(
+      "Rolled step {} with karma: {}\n",
+      step_value, step_roll
+    ));
   }
   output.pop(); // delete the trailing newline
 
@@ -96,7 +106,11 @@ fn earthdawn_karma(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResu
 fn earthdawn_target(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
 
-  let inputs: Vec<i32> = args.rest().split_whitespace().filter_map(basic_sum_str).collect();
+  let inputs: Vec<i32> = args
+    .rest()
+    .split_whitespace()
+    .filter_map(basic_sum_str)
+    .collect();
   match &inputs as &[i32] {
     [step_value, target] => {
       let step_roll = step(gen, *step_value, false);
@@ -105,9 +119,11 @@ fn earthdawn_target(_ctx: &mut Context, msg: &Message, args: Args) -> CommandRes
       } else {
         0
       };
-      let es_for_successes = if successes != 1 { "es" } else { ""};
-      let output = format!("Rolled step {} vs {}: got {} ({} success{})",
-        step_value, target, step_roll, successes, es_for_successes);
+      let es_for_successes = if successes != 1 { "es" } else { "" };
+      let output = format!(
+        "Rolled step {} vs {}: got {} ({} success{})",
+        step_value, target, step_roll, successes, es_for_successes
+      );
       if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
         println!("Error sending message: {:?}", why);
       }

--- a/src/earthdawn.rs
+++ b/src/earthdawn.rs
@@ -8,6 +8,12 @@ use serenity::{
   },
 };
 
+group!({
+  name: "earthdawn",
+  options: {},
+  commands: [earthdawn, earthdawn_karma, earthdawn_target]
+});
+
 /// Rolls a step roll, according to the 4th edition chart.
 pub fn step(gen: &mut PCG32, mut step: i32, karma: bool) -> i32 {
   if step < 1 {

--- a/src/earthdawn.rs
+++ b/src/earthdawn.rs
@@ -5,11 +5,7 @@ use serenity::{
   framework::standard::macros::*,
   model::{
     channel::*,
-    gateway::*,
-    event::*,
-    id::*,
   },
-  prelude::*,
 };
 
 /// Rolls a step roll, according to the 4th edition chart.
@@ -19,27 +15,27 @@ pub fn step(gen: &mut PCG32, mut step: i32, karma: bool) -> i32 {
   } else {
     let mut total = 0;
     while step > 13 {
-      total += d12.explode(gen);
+      total += D12.explode(gen);
       step -= 7;
     }
     (total
       + match step {
-        1 => (d4.explode(gen) as i32 - 2).max(1) as u32,
-        2 => (d4.explode(gen) as i32 - 1).max(1) as u32,
-        3 => d4.explode(gen),
-        4 => d6.explode(gen),
-        5 => d8.explode(gen),
-        6 => d10.explode(gen),
-        7 => d12.explode(gen),
-        8 => d6.explode(gen) + d6.explode(gen),
-        9 => d8.explode(gen) + d6.explode(gen),
-        10 => d8.explode(gen) + d8.explode(gen),
-        11 => d10.explode(gen) + d8.explode(gen),
-        12 => d10.explode(gen) + d10.explode(gen),
-        13 => d12.explode(gen) + d10.explode(gen),
+        1 => (D4.explode(gen) as i32 - 2).max(1) as u32,
+        2 => (D4.explode(gen) as i32 - 1).max(1) as u32,
+        3 => D4.explode(gen),
+        4 => D6.explode(gen),
+        5 => D8.explode(gen),
+        6 => D10.explode(gen),
+        7 => D12.explode(gen),
+        8 => D6.explode(gen) + D6.explode(gen),
+        9 => D8.explode(gen) + D6.explode(gen),
+        10 => D8.explode(gen) + D8.explode(gen),
+        11 => D10.explode(gen) + D8.explode(gen),
+        12 => D10.explode(gen) + D10.explode(gen),
+        13 => D12.explode(gen) + D10.explode(gen),
         _other => unreachable!(),
       }
-      + if karma { d6.explode(gen) } else { 0 }) as i32
+      + if karma { D6.explode(gen) } else { 0 }) as i32
   }
 }
 

--- a/src/earthdawn.rs
+++ b/src/earthdawn.rs
@@ -1,4 +1,16 @@
 use super::*;
+use serenity::{
+  client::*,
+  framework::standard::*,
+  framework::standard::macros::*,
+  model::{
+    channel::*,
+    gateway::*,
+    event::*,
+    id::*,
+  },
+  prelude::*,
+};
 
 /// Rolls a step roll, according to the 4th edition chart.
 pub fn step(gen: &mut PCG32, mut step: i32, karma: bool) -> i32 {
@@ -31,44 +43,58 @@ pub fn step(gen: &mut PCG32, mut step: i32, karma: bool) -> i32 {
   }
 }
 
-command!(earthdawn(_ctx, msg, args) {
+#[command]
+#[aliases("ed")]
+#[description = "Rolls an Earthdawn 4e step (up to 10)"]
+#[usage = "STEP [...]"]
+fn earthdawn(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
 
-  for step_value in args.full().split_whitespace().take(10).filter_map(basic_sum_str) {
+  for step_value in args.rest().split_whitespace().take(10).filter_map(basic_sum_str) {
     let step_roll = step(gen, step_value, false);
     output.push_str(&format!("Rolled step {}: {}\n", step_value, step_roll));
   }
   output.pop(); // delete the trailing newline
 
   if output.len() > 0 {
-    if let Err(why) = msg.channel_id.say(output) {
+    if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
       println!("Error sending message: {:?}", why);
     }
   }
-});
+  Ok(())
+}
 
-command!(earthdawn_karma(_ctx, msg, args) {
+#[command]
+#[description = "Rolls an Earthdawn 4e step with karma (up to 10)"]
+#[aliases("edk")]
+#[usage = "STEP [...]"]
+fn earthdawn_karma(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
 
-  for step_value in args.full().split_whitespace().take(10).filter_map(basic_sum_str) {
+  for step_value in args.rest().split_whitespace().take(10).filter_map(basic_sum_str) {
     let step_roll = step(gen, step_value, true);
     output.push_str(&format!("Rolled step {} with karma: {}\n", step_value, step_roll));
   }
   output.pop(); // delete the trailing newline
 
   if output.len() > 0 {
-    if let Err(why) = msg.channel_id.say(output) {
+    if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
       println!("Error sending message: {:?}", why);
     }
   }
-});
+  Ok(())
+}
 
-command!(earthdawn_target(_ctx, msg, args) {
+#[command]
+#[description = "Rolls an Earthdawn 4e step"]
+#[usage = "STEP TARGET"]
+#[aliases("edt")]
+fn earthdawn_target(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
 
-  let inputs: Vec<i32> = args.full().split_whitespace().filter_map(basic_sum_str).collect();
+  let inputs: Vec<i32> = args.rest().split_whitespace().filter_map(basic_sum_str).collect();
   match &inputs as &[i32] {
     [step_value, target] => {
       let step_roll = step(gen, *step_value, false);
@@ -80,14 +106,15 @@ command!(earthdawn_target(_ctx, msg, args) {
       let es_for_successes = if successes != 1 { "es" } else { ""};
       let output = format!("Rolled step {} vs {}: got {} ({} success{})",
         step_value, target, step_roll, successes, es_for_successes);
-      if let Err(why) = msg.channel_id.say(output) {
+      if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
         println!("Error sending message: {:?}", why);
       }
     }
     _ => {
-      if let Err(why) = msg.channel_id.say("usage: STEP TARGET") {
+      if let Err(why) = msg.channel_id.say(&_ctx.http, "usage: STEP TARGET") {
         println!("Error sending message: {:?}", why);
       }
     }
   }
-});
+  Ok(())
+}

--- a/src/eote.rs
+++ b/src/eote.rs
@@ -1,4 +1,16 @@
 use super::*;
+use serenity::{
+  client::*,
+  framework::standard::*,
+  framework::standard::macros::*,
+  model::{
+    channel::*,
+    gateway::*,
+    event::*,
+    id::*,
+  },
+  prelude::*,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub enum Symbol {
@@ -114,10 +126,14 @@ fn white(gen: &mut PCG32) -> &'static [Symbol] {
   }
 }
 
-command!(eote(_ctx, msg, args) {
+#[command]
+#[aliases("eote")]
+#[description = "Rolls EotE dice (b=black, u=blue)"]
+#[usage = "EXPRESSION [...]"]
+fn eote(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let gen: &mut PCG32 = &mut global_gen();
   let mut output = String::new();
-  let terms: Vec<&str> = args.full().split_whitespace().collect();
+  let terms: Vec<&str> = args.rest().split_whitespace().collect();
   'termloop: for term in terms {
     let mut pool_string = String::new();
     for ch in term.chars() {
@@ -212,12 +228,13 @@ command!(eote(_ctx, msg, args) {
   }
   output.pop();
   if output.len() > 0 {
-    if let Err(why) = msg.channel_id.say(output) {
+    if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
       println!("Error sending message: {:?}", why);
     }
   } else {
-    if let Err(why) = msg.channel_id.say("usage: eote POOL (black = b, blue = u)") {
+    if let Err(why) = msg.channel_id.say(&_ctx.http, "usage: eote POOL (black = b, blue = u)") {
       println!("Error sending message: {:?}", why);
     }
   }
-});
+  Ok(())
+}

--- a/src/eote.rs
+++ b/src/eote.rs
@@ -1,11 +1,8 @@
 use super::*;
 use serenity::{
   client::*,
-  framework::standard::*,
-  framework::standard::macros::*,
-  model::{
-    channel::*,
-  },
+  framework::standard::{macros::*, *},
+  model::channel::*,
 };
 
 group!({
@@ -28,25 +25,25 @@ pub enum Symbol {
 use self::Symbol::*;
 
 // goods
-static BLANK: &'static [Symbol] = &[];
-static TWO_ADVANTAGE: &'static [Symbol] = &[Advantage, Advantage];
-static ONE_ADVANTAGE: &'static [Symbol] = &[Advantage];
-static ADVANTAGE_SUCCESS: &'static [Symbol] = &[Advantage, Success];
-static ONE_SUCCESS: &'static [Symbol] = &[Success];
-static TWO_SUCCESS: &'static [Symbol] = &[Success, Success];
-static THE_TRIUMPH: &'static [Symbol] = &[Success, Triumph];
+static BLANK: &[Symbol] = &[];
+static TWO_ADVANTAGE: &[Symbol] = &[Advantage, Advantage];
+static ONE_ADVANTAGE: &[Symbol] = &[Advantage];
+static ADVANTAGE_SUCCESS: &[Symbol] = &[Advantage, Success];
+static ONE_SUCCESS: &[Symbol] = &[Success];
+static TWO_SUCCESS: &[Symbol] = &[Success, Success];
+static THE_TRIUMPH: &[Symbol] = &[Success, Triumph];
 // bads
-static ONE_DISADVANTAGE: &'static [Symbol] = &[Disadvantage];
-static TWO_DISADVANTAGE: &'static [Symbol] = &[Disadvantage, Disadvantage];
-static ONE_FAILURE: &'static [Symbol] = &[Failure];
-static TWO_FAILURE: &'static [Symbol] = &[Failure, Failure];
-static DISADVANTAGE_FAILURE: &'static [Symbol] = &[Disadvantage, Failure];
-static THE_DESPAIR: &'static [Symbol] = &[Failure, Despair];
+static ONE_DISADVANTAGE: &[Symbol] = &[Disadvantage];
+static TWO_DISADVANTAGE: &[Symbol] = &[Disadvantage, Disadvantage];
+static ONE_FAILURE: &[Symbol] = &[Failure];
+static TWO_FAILURE: &[Symbol] = &[Failure, Failure];
+static DISADVANTAGE_FAILURE: &[Symbol] = &[Disadvantage, Failure];
+static THE_DESPAIR: &[Symbol] = &[Failure, Despair];
 // force
-static ONE_DARK: &'static [Symbol] = &[Dark];
-static TWO_DARK: &'static [Symbol] = &[Dark, Dark];
-static ONE_LIGHT: &'static [Symbol] = &[Light];
-static TWO_LIGHT: &'static [Symbol] = &[Light, Light];
+static ONE_DARK: &[Symbol] = &[Dark];
+static TWO_DARK: &[Symbol] = &[Dark, Dark];
+static ONE_LIGHT: &[Symbol] = &[Light];
+static TWO_LIGHT: &[Symbol] = &[Light, Light];
 
 fn blue(gen: &mut PCG32) -> &'static [Symbol] {
   match D6.sample(gen) {
@@ -178,18 +175,18 @@ fn eote(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
           Light => lights += 1,
           Dark => darks += 1,
         }
-      };
+      }
     }
     let mut symbol_total_string = String::new();
     if successes > 0 {
-      symbol_total_string.push_str(&format!("{} Success",successes));
+      symbol_total_string.push_str(&format!("{} Success", successes));
       if successes > 1 {
         symbol_total_string.push_str("es, ");
       } else {
         symbol_total_string.push_str(", ");
       }
     } else if successes < 0 {
-      symbol_total_string.push_str(&format!("{} Failure",successes.abs()));
+      symbol_total_string.push_str(&format!("{} Failure", successes.abs()));
       if successes < -1 {
         symbol_total_string.push_str("s, ");
       } else {
@@ -199,23 +196,28 @@ fn eote(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
       symbol_total_string.push_str("0 Failures, ");
     }
     if advantages > 0 {
-      symbol_total_string.push_str(&format!("{} Advantage",advantages));
+      symbol_total_string.push_str(&format!("{} Advantage", advantages));
       if advantages > 1 {
         symbol_total_string.push_str("s, ");
       } else {
         symbol_total_string.push_str(", ");
       }
     } else if advantages < 0 {
-      symbol_total_string.push_str(&format!("{} Disadvantage",advantages.abs()));
+      symbol_total_string.push_str(&format!("{} Disadvantage", advantages.abs()));
       if advantages < -1 {
         symbol_total_string.push_str("s, ");
       } else {
         symbol_total_string.push_str(", ");
       }
     }
-    for (quantity, symbol) in &[(triumphs, Triumph), (despairs, Despair), (lights, Light), (darks, Dark)] {
+    for (quantity, symbol) in &[
+      (triumphs, Triumph),
+      (despairs, Despair),
+      (lights, Light),
+      (darks, Dark),
+    ] {
       if *quantity > 0 {
-        symbol_total_string.push_str(&format!("{} {:?}",quantity, symbol));
+        symbol_total_string.push_str(&format!("{} {:?}", quantity, symbol));
         if *quantity > 1 {
           symbol_total_string.push_str("s, ");
         } else {
@@ -223,20 +225,24 @@ fn eote(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
         }
       }
     }
-    for _ in 0 .. 2 {
+    for _ in 0..2 {
       symbol_total_string.pop();
     }
-    output.push_str(&format!("Rolled {}: {}\n", pool_string, symbol_total_string));
+    output.push_str(&format!(
+      "Rolled {}: {}\n",
+      pool_string, symbol_total_string
+    ));
   }
   output.pop();
   if output.len() > 0 {
     if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
       println!("Error sending message: {:?}", why);
     }
-  } else {
-    if let Err(why) = msg.channel_id.say(&_ctx.http, "usage: eote POOL (black = b, blue = u)") {
-      println!("Error sending message: {:?}", why);
-    }
+  } else if let Err(why) = msg
+    .channel_id
+    .say(&_ctx.http, "usage: eote POOL (black = b, blue = u)")
+  {
+    println!("Error sending message: {:?}", why);
   }
   Ok(())
 }

--- a/src/eote.rs
+++ b/src/eote.rs
@@ -8,6 +8,12 @@ use serenity::{
   },
 };
 
+group!({
+  name: "eote",
+  options: {},
+  commands: [eote]
+});
+
 #[derive(Debug, Clone, Copy)]
 pub enum Symbol {
   Success,

--- a/src/eote.rs
+++ b/src/eote.rs
@@ -5,11 +5,7 @@ use serenity::{
   framework::standard::macros::*,
   model::{
     channel::*,
-    gateway::*,
-    event::*,
-    id::*,
   },
-  prelude::*,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -47,7 +43,7 @@ static ONE_LIGHT: &'static [Symbol] = &[Light];
 static TWO_LIGHT: &'static [Symbol] = &[Light, Light];
 
 fn blue(gen: &mut PCG32) -> &'static [Symbol] {
-  match d6.sample(gen) {
+  match D6.sample(gen) {
     1 | 2 => BLANK,
     3 => TWO_ADVANTAGE,
     4 => ONE_ADVANTAGE,
@@ -58,7 +54,7 @@ fn blue(gen: &mut PCG32) -> &'static [Symbol] {
 }
 
 fn black(gen: &mut PCG32) -> &'static [Symbol] {
-  match d6.sample(gen) {
+  match D6.sample(gen) {
     1 | 2 => BLANK,
     3 | 4 => ONE_FAILURE,
     5 | 6 => ONE_DISADVANTAGE,
@@ -67,7 +63,7 @@ fn black(gen: &mut PCG32) -> &'static [Symbol] {
 }
 
 fn green(gen: &mut PCG32) -> &'static [Symbol] {
-  match d8.sample(gen) {
+  match D8.sample(gen) {
     1 => BLANK,
     2 | 3 => ONE_SUCCESS,
     4 => TWO_SUCCESS,
@@ -79,7 +75,7 @@ fn green(gen: &mut PCG32) -> &'static [Symbol] {
 }
 
 fn purple(gen: &mut PCG32) -> &'static [Symbol] {
-  match d8.sample(gen) {
+  match D8.sample(gen) {
     1 => BLANK,
     2 => ONE_FAILURE,
     3 => TWO_FAILURE,
@@ -91,7 +87,7 @@ fn purple(gen: &mut PCG32) -> &'static [Symbol] {
 }
 
 fn yellow(gen: &mut PCG32) -> &'static [Symbol] {
-  match d12.sample(gen) {
+  match D12.sample(gen) {
     1 => BLANK,
     2 | 3 => ONE_SUCCESS,
     4 | 5 => TWO_SUCCESS,
@@ -104,7 +100,7 @@ fn yellow(gen: &mut PCG32) -> &'static [Symbol] {
 }
 
 fn red(gen: &mut PCG32) -> &'static [Symbol] {
-  match d12.sample(gen) {
+  match D12.sample(gen) {
     1 => BLANK,
     2 | 3 => ONE_FAILURE,
     4 | 5 => TWO_FAILURE,
@@ -117,7 +113,7 @@ fn red(gen: &mut PCG32) -> &'static [Symbol] {
 }
 
 fn white(gen: &mut PCG32) -> &'static [Symbol] {
-  match d12.sample(gen) {
+  match D12.sample(gen) {
     1 | 2 | 3 | 4 | 5 | 6 => ONE_DARK,
     7 => TWO_DARK,
     8 | 9 => ONE_LIGHT,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,33 +1,36 @@
+#![allow(clippy::len_zero)]
+
+use lazy_static::lazy_static;
+use lokacore::*;
 use randomize::*;
 use std::sync::{Mutex, MutexGuard};
-use lokacore::*;
-#[macro_use]
-extern crate lazy_static;
 
 pub mod earthdawn;
 pub mod eote;
 pub mod shadowrun;
 
-pub const D4: RandRangeU32 = RandRangeU32::new(1,4);
-pub const D6: RandRangeU32 = RandRangeU32::new(1,6);
-pub const D8: RandRangeU32 = RandRangeU32::new(1,8);
-pub const D10: RandRangeU32 = RandRangeU32::new(1,10);
-pub const D12: RandRangeU32 = RandRangeU32::new(1,12);
-pub const D20: RandRangeU32 = RandRangeU32::new(1,20);
+pub const D4: RandRangeU32 = RandRangeU32::new(1, 4);
+pub const D6: RandRangeU32 = RandRangeU32::new(1, 6);
+pub const D8: RandRangeU32 = RandRangeU32::new(1, 8);
+pub const D10: RandRangeU32 = RandRangeU32::new(1, 10);
+pub const D12: RandRangeU32 = RandRangeU32::new(1, 12);
+pub const D20: RandRangeU32 = RandRangeU32::new(1, 20);
 
 lazy_static! {
   static ref GLOBAL_GEN: Mutex<PCG32> = Mutex::new(PCG32::default());
 }
 
 pub fn global_gen() -> MutexGuard<'static, PCG32> {
-  GLOBAL_GEN.lock().unwrap_or_else(|poison|poison.into_inner())
+  GLOBAL_GEN
+    .lock()
+    .unwrap_or_else(|poison| poison.into_inner())
 }
 pub fn just_seed_the_global_gen() {
   let gen: &mut PCG32 = &mut global_gen();
   let mut arr: [u64; 2] = [0, 0];
   match getrandom::getrandom(bytes_of_mut(&mut arr)) {
     Ok(_) => *gen = PCG32::seed(arr[0], arr[1]),
-    Err(_) => *gen = PCG32::default()
+    Err(_) => *gen = PCG32::default(),
   }
 }
 
@@ -59,9 +62,9 @@ pub fn basic_sum_str(s: &str) -> Option<i32> {
   let mut current_is_negative = s.chars().nth(0).unwrap() == '-';
   for ch in s.chars() {
     match ch {
-      '0' ..= '9' => {
-          current *= 10;
-          current += ch.to_digit(10).unwrap() as i32;
+      '0'..='9' => {
+        current *= 10;
+        current += ch.to_digit(10).unwrap() as i32;
       }
       '+' => {
         total += if current_is_negative {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
-
 use randomize::*;
 use std::sync::{Mutex, MutexGuard};
 use lokacore::*;
+#[macro_use]
+extern crate lazy_static;
 
 pub mod earthdawn;
 pub mod eote;
@@ -14,7 +15,10 @@ const d10: RandRangeU32 = RandRangeU32::new(1,10);
 const d12: RandRangeU32 = RandRangeU32::new(1,12);
 const d20: RandRangeU32 = RandRangeU32::new(1,20);
 
-static GLOBAL_GEN: Mutex<PCG32> = Mutex::new(PCG32::default());
+lazy_static! {
+  static ref GLOBAL_GEN: Mutex<PCG32> = Mutex::new(PCG32::default());
+}
+
 pub fn global_gen() -> MutexGuard<'static, PCG32> {
   GLOBAL_GEN.lock().unwrap_or_else(|poison|poison.into_inner())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate serenity;
 
-extern crate randomize;
 use randomize::*;
 
 pub mod earthdawn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,12 @@ pub mod earthdawn;
 pub mod eote;
 pub mod shadowrun;
 
-pub const d4: RandRangeU32 = RandRangeU32::new(1,4);
-pub const d6: RandRangeU32 = RandRangeU32::new(1,6);
-pub const d8: RandRangeU32 = RandRangeU32::new(1,8);
-pub const d10: RandRangeU32 = RandRangeU32::new(1,10);
-pub const d12: RandRangeU32 = RandRangeU32::new(1,12);
-pub const d20: RandRangeU32 = RandRangeU32::new(1,20);
+pub const D4: RandRangeU32 = RandRangeU32::new(1,4);
+pub const D6: RandRangeU32 = RandRangeU32::new(1,6);
+pub const D8: RandRangeU32 = RandRangeU32::new(1,8);
+pub const D10: RandRangeU32 = RandRangeU32::new(1,10);
+pub const D12: RandRangeU32 = RandRangeU32::new(1,12);
+pub const D20: RandRangeU32 = RandRangeU32::new(1,20);
 
 lazy_static! {
   static ref GLOBAL_GEN: Mutex<PCG32> = Mutex::new(PCG32::default());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,12 @@ pub mod earthdawn;
 pub mod eote;
 pub mod shadowrun;
 
-const d4: RandRangeU32 = RandRangeU32::new(1,4);
-const d6: RandRangeU32 = RandRangeU32::new(1,6);
-const d8: RandRangeU32 = RandRangeU32::new(1,8);
-const d10: RandRangeU32 = RandRangeU32::new(1,10);
-const d12: RandRangeU32 = RandRangeU32::new(1,12);
-const d20: RandRangeU32 = RandRangeU32::new(1,20);
+pub const d4: RandRangeU32 = RandRangeU32::new(1,4);
+pub const d6: RandRangeU32 = RandRangeU32::new(1,6);
+pub const d8: RandRangeU32 = RandRangeU32::new(1,8);
+pub const d10: RandRangeU32 = RandRangeU32::new(1,10);
+pub const d12: RandRangeU32 = RandRangeU32::new(1,12);
+pub const d20: RandRangeU32 = RandRangeU32::new(1,20);
 
 lazy_static! {
   static ref GLOBAL_GEN: Mutex<PCG32> = Mutex::new(PCG32::default());

--- a/src/shadowrun.rs
+++ b/src/shadowrun.rs
@@ -1,11 +1,8 @@
 use super::*;
 use serenity::{
   client::*,
-  framework::standard::*,
-  framework::standard::macros::*,
-  model::{
-    channel::*,
-  },
+  framework::standard::{macros::*, *},
+  model::channel::*,
 };
 
 group!({
@@ -121,8 +118,16 @@ macro_rules! do_the_dice_pool {
 #[usage = "DICE [...]"]
 fn shadowrun(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let mut output = String::new();
-  for dice_count in args.rest().split_whitespace().take(10).filter_map(basic_sum_str) {
-    format_the_dice_report!(output, do_the_dice_pool!(output, "Rolled", dice_count, false, "dice"));
+  for dice_count in args
+    .rest()
+    .split_whitespace()
+    .take(10)
+    .filter_map(basic_sum_str)
+  {
+    format_the_dice_report!(
+      output,
+      do_the_dice_pool!(output, "Rolled", dice_count, false, "dice")
+    );
     output.push('\n');
   }
   output.pop();
@@ -140,8 +145,22 @@ fn shadowrun(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
 #[usage = "DICE [...]"]
 fn shadowrun_edge(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let mut output = String::new();
-  for dice_count in args.rest().split_whitespace().take(10).filter_map(basic_sum_str) {
-    format_the_dice_report!(output, do_the_dice_pool!(output, "Rolled", dice_count, true, "dice with edge (6-again)"));
+  for dice_count in args
+    .rest()
+    .split_whitespace()
+    .take(10)
+    .filter_map(basic_sum_str)
+  {
+    format_the_dice_report!(
+      output,
+      do_the_dice_pool!(
+        output,
+        "Rolled",
+        dice_count,
+        true,
+        "dice with edge (6-again)"
+      )
+    );
     output.push('\n');
   }
   output.pop();
@@ -159,7 +178,11 @@ fn shadowrun_edge(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResul
 #[usage = "CONJURE FORCE SOAK"]
 fn shadowrun_friend(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let mut output = String::new();
-  let terms: Vec<i32> = args.rest().split_whitespace().filter_map(basic_sum_str).collect();
+  let terms: Vec<i32> = args
+    .rest()
+    .split_whitespace()
+    .filter_map(basic_sum_str)
+    .collect();
   match &terms as &[i32] {
     [conjure, force, soak] => {
       let conjure = *conjure;
@@ -170,18 +193,23 @@ fn shadowrun_friend(_ctx: &mut Context, msg: &Message, args: Args) -> CommandRes
       } else if force < 1 {
         output.push_str("There's no Force there!")
       } else {
-        let conjure_output = do_the_dice_pool!(output, "You rolled", conjure, false, "dice to conjure");
+        let conjure_output =
+          do_the_dice_pool!(output, "You rolled", conjure, false, "dice to conjure");
         {
           format_the_dice_report!(output, conjure_output);
           output.push('\n');
         }
         let conjure_hits = conjure_output.hits_total;
         //
-        let force_output = do_the_dice_pool!(output, "Your friend rolled", force, false, "dice to resist");
+        let force_output =
+          do_the_dice_pool!(output, "Your friend rolled", force, false, "dice to resist");
         {
           let services_owed = (conjure_hits as i32 - force_output.hits_total as i32).max(0);
           let s_for_services_owed = if services_owed != 1 { "s" } else { "" };
-          output.push_str(&format!(" ({} service{} owed)", services_owed, s_for_services_owed));
+          output.push_str(&format!(
+            " ({} service{} owed)",
+            services_owed, s_for_services_owed
+          ));
           format_the_dice_report!(output, force_output);
           output.push('\n');
         }
@@ -189,7 +217,7 @@ fn shadowrun_friend(_ctx: &mut Context, msg: &Message, args: Args) -> CommandRes
         //
         let soak_output = do_the_dice_pool!(output, "Your rolled", soak, false, "dice to soak");
         {
-          let net_drain = ((force/2 + force_hits) - soak_output.hits_total as i32).max(0);
+          let net_drain = ((force / 2 + force_hits) - soak_output.hits_total as i32).max(0);
           output.push_str(&format!(" ({} net drain)", net_drain));
           format_the_dice_report!(output, soak_output);
         }
@@ -211,7 +239,11 @@ fn shadowrun_friend(_ctx: &mut Context, msg: &Message, args: Args) -> CommandRes
 #[usage = "BINDING FORCE SOAK"]
 fn shadowrun_foe(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let mut output = String::new();
-  let terms: Vec<i32> = args.rest().split_whitespace().filter_map(basic_sum_str).collect();
+  let terms: Vec<i32> = args
+    .rest()
+    .split_whitespace()
+    .filter_map(basic_sum_str)
+    .collect();
   match &terms as &[i32] {
     [bind, force, soak] => {
       let bind = *bind;
@@ -229,15 +261,24 @@ fn shadowrun_foe(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult
         }
         let bind_hits = bind_output.hits_total;
         //
-        let force_dice = force*2;
-        let force_output = do_the_dice_pool!(output, "Your victim rolled", force_dice, false, "dice to resist");
+        let force_dice = force * 2;
+        let force_output = do_the_dice_pool!(
+          output,
+          "Your victim rolled",
+          force_dice,
+          false,
+          "dice to resist"
+        );
         {
           let binding_net_hits = (bind_hits as i32 - force_output.hits_total as i32).max(0);
           if binding_net_hits == 0 {
             output.push_str(" (failed to bind!)\n");
           } else {
             let s_for_binding_net_hits = if binding_net_hits > 1 { "s" } else { "" };
-            output.push_str(&format!(" ({} net hit{})", binding_net_hits, s_for_binding_net_hits));
+            output.push_str(&format!(
+              " ({} net hit{})",
+              binding_net_hits, s_for_binding_net_hits
+            ));
             format_the_dice_report!(output, force_output);
             output.push('\n');
           }
@@ -246,7 +287,7 @@ fn shadowrun_foe(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult
         //
         let soak_output = do_the_dice_pool!(output, "Your rolled", soak, false, "dice to soak");
         {
-          let net_drain = ((force/2 + force_hits) - soak_output.hits_total as i32).max(0);
+          let net_drain = ((force / 2 + force_hits) - soak_output.hits_total as i32).max(0);
           output.push_str(&format!(" ({} net drain)", net_drain));
           format_the_dice_report!(output, soak_output);
         }
@@ -268,7 +309,11 @@ fn shadowrun_foe(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult
 #[aliases("sra")]
 fn shadowrun_attack(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let mut output = String::new();
-  let terms: Vec<i32> = args.rest().split_whitespace().filter_map(basic_sum_str).collect();
+  let terms: Vec<i32> = args
+    .rest()
+    .split_whitespace()
+    .filter_map(basic_sum_str)
+    .collect();
   match &terms as &[i32] {
     [attack, evade, damage, soak] => {
       if *attack < 1 {
@@ -279,7 +324,8 @@ fn shadowrun_attack(_ctx: &mut Context, msg: &Message, args: Args) -> CommandRes
         let damage = *damage as u32;
         let soak = (*soak).max(0) as u32;
         //
-        let attack_output = do_the_dice_pool!(output, "You rolled", attack, false, "dice to attack");
+        let attack_output =
+          do_the_dice_pool!(output, "You rolled", attack, false, "dice to attack");
         {
           format_the_dice_report!(output, attack_output);
           output.push('\n');
@@ -298,14 +344,17 @@ fn shadowrun_attack(_ctx: &mut Context, msg: &Message, args: Args) -> CommandRes
         } else {
           let s_for_net_hits = if attack_net_hits != 1 { "s" } else { "" };
           let modified_damage = damage as i32 + attack_net_hits;
-          output.push_str(&format!(" ({} net hit{}, modified damage is {})",attack_net_hits, s_for_net_hits, modified_damage));
+          output.push_str(&format!(
+            " ({} net hit{}, modified damage is {})",
+            attack_net_hits, s_for_net_hits, modified_damage
+          ));
           format_the_dice_report!(output, evade_output);
           output.push('\n');
           //
           let soak_output = do_the_dice_pool!(output, "They rolled", soak, false, "dice to soak");
           {
             let damage_after_soak = (modified_damage - soak_output.hits_total as i32).max(0);
-            output.push_str(&format!(" ({} damage after soak)",damage_after_soak));
+            output.push_str(&format!(" ({} damage after soak)", damage_after_soak));
             format_the_dice_report!(output, soak_output);
             output.push('\n');
           }

--- a/src/shadowrun.rs
+++ b/src/shadowrun.rs
@@ -1,4 +1,16 @@
 use super::*;
+use serenity::{
+  client::*,
+  framework::standard::*,
+  framework::standard::macros::*,
+  model::{
+    channel::*,
+    gateway::*,
+    event::*,
+    id::*,
+  },
+  prelude::*,
+};
 
 const SR_POOL_MAX_REPORT: u32 = 30;
 
@@ -101,37 +113,51 @@ macro_rules! do_the_dice_pool {
   }};
 }
 
-command!(shadowrun(_ctx, msg, args) {
+#[command]
+#[description = "Rolls Shadowrun 4e style (up to 10)"]
+#[aliases("sr")]
+#[usage = "DICE [...]"]
+fn shadowrun(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let mut output = String::new();
-  for dice_count in args.full().split_whitespace().take(10).filter_map(basic_sum_str) {
+  for dice_count in args.rest().split_whitespace().take(10).filter_map(basic_sum_str) {
     format_the_dice_report!(output, do_the_dice_pool!(output, "Rolled", dice_count, false, "dice"));
     output.push('\n');
   }
   output.pop();
   if output.len() > 0 {
-    if let Err(why) = msg.channel_id.say(output) {
+    if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
       println!("Error sending message: {:?}", why);
     }
   }
-});
+  Ok(())
+}
 
-command!(shadowrun_edge(_ctx, msg, args) {
+#[command]
+#[aliases("sre")]
+#[description = "Rolls Shadowrun 4e with 6-again (up to 10)"]
+#[usage = "DICE [...]"]
+fn shadowrun_edge(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let mut output = String::new();
-  for dice_count in args.full().split_whitespace().take(10).filter_map(basic_sum_str) {
+  for dice_count in args.rest().split_whitespace().take(10).filter_map(basic_sum_str) {
     format_the_dice_report!(output, do_the_dice_pool!(output, "Rolled", dice_count, true, "dice with edge (6-again)"));
     output.push('\n');
   }
   output.pop();
   if output.len() > 0 {
-    if let Err(why) = msg.channel_id.say(output) {
+    if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
       println!("Error sending message: {:?}", why);
     }
   }
-});
+  Ok(())
+}
 
-command!(shadowrun_friend(_ctx, msg, args) {
+#[command]
+#[aliases("friend")]
+#[description = "Rolls up a conjured buddy (Spirit / Sprite)"]
+#[usage = "CONJURE FORCE SOAK"]
+fn shadowrun_friend(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let mut output = String::new();
-  let terms: Vec<i32> = args.full().split_whitespace().filter_map(basic_sum_str).collect();
+  let terms: Vec<i32> = args.rest().split_whitespace().filter_map(basic_sum_str).collect();
   match &terms as &[i32] {
     [conjure, force, soak] => {
       let conjure = *conjure;
@@ -171,14 +197,19 @@ command!(shadowrun_friend(_ctx, msg, args) {
       output.push_str("Usage: CONJURE FORCE SOAK");
     }
   }
-  if let Err(why) = msg.channel_id.say(output) {
+  if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
     println!("Error sending message: {:?}", why);
   }
-});
+  Ok(())
+}
 
-command!(shadowrun_foe(_ctx, msg, args) {
+#[command]
+#[description = "Binds a conjured buddy (Spirit / Sprite)"]
+#[aliases("foe")]
+#[usage = "BINDING FORCE SOAK"]
+fn shadowrun_foe(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let mut output = String::new();
-  let terms: Vec<i32> = args.full().split_whitespace().filter_map(basic_sum_str).collect();
+  let terms: Vec<i32> = args.rest().split_whitespace().filter_map(basic_sum_str).collect();
   match &terms as &[i32] {
     [bind, force, soak] => {
       let bind = *bind;
@@ -223,14 +254,19 @@ command!(shadowrun_foe(_ctx, msg, args) {
       output.push_str("Usage: CONJURE FORCE SOAK");
     }
   }
-  if let Err(why) = msg.channel_id.say(output) {
+  if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
     println!("Error sending message: {:?}", why);
   }
-});
+  Ok(())
+}
 
-command!(shadowrun_attack(_ctx, msg, args) {
+#[command]
+#[description = "Rolls a Shadowrun 4e attack cycle"]
+#[usage = "ATTACK EVADE DAMAGE SOAK"]
+#[aliases("sra")]
+fn shadowrun_attack(_ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
   let mut output = String::new();
-  let terms: Vec<i32> = args.full().split_whitespace().filter_map(basic_sum_str).collect();
+  let terms: Vec<i32> = args.rest().split_whitespace().filter_map(basic_sum_str).collect();
   match &terms as &[i32] {
     [attack, evade, damage, soak] => {
       if *attack < 1 {
@@ -278,7 +314,8 @@ command!(shadowrun_attack(_ctx, msg, args) {
       output.push_str("Usage: ATTACK EVADE DAMAGE SOAK");
     }
   }
-  if let Err(why) = msg.channel_id.say(output) {
+  if let Err(why) = msg.channel_id.say(&_ctx.http, output) {
     println!("Error sending message: {:?}", why);
   }
-});
+  Ok(())
+}

--- a/src/shadowrun.rs
+++ b/src/shadowrun.rs
@@ -5,11 +5,7 @@ use serenity::{
   framework::standard::macros::*,
   model::{
     channel::*,
-    gateway::*,
-    event::*,
-    id::*,
   },
-  prelude::*,
 };
 
 const SR_POOL_MAX_REPORT: u32 = 30;
@@ -44,7 +40,7 @@ pub fn sr4(pool_size: u32, six_again: bool) -> PoolRollOutput {
     let mut ones = 0;
     let mut this_is_a_normal_roll = true;
     while dice_rolled < pool_size {
-      let roll = d6.sample(gen);
+      let roll = D6.sample(gen);
       if roll == 1 && this_is_a_normal_roll {
         ones += 1;
       } else if roll >= 5 {

--- a/src/shadowrun.rs
+++ b/src/shadowrun.rs
@@ -8,6 +8,12 @@ use serenity::{
   },
 };
 
+group!({
+  name: "shadowrun",
+  options: {},
+  commands: [shadowrun, shadowrun_edge, shadowrun_friend, shadowrun_foe, shadowrun_attack]
+});
+
 const SR_POOL_MAX_REPORT: u32 = 30;
 
 pub struct PoolRollOutput {

--- a/src/shadowrun.rs
+++ b/src/shadowrun.rs
@@ -18,11 +18,11 @@ pub fn glitch_string(hits: u32, is_glitch: bool) -> &'static str {
 
 pub fn sr4(pool_size: u32, six_again: bool) -> PoolRollOutput {
   if pool_size == 0 {
-    return PoolRollOutput {
+    PoolRollOutput {
       hits_total: 0,
       is_glitch: false,
       roll_list: None,
-    };
+    }
   } else {
     let gen: &mut PCG32 = &mut global_gen();
     let mut dice_record: Vec<u8> = vec![];


### PR DESCRIPTION
Here's where we'll get Dicebot to use serenity 0.6, which is apparently quite the ride.

Reference links I'll probably need to read:
* https://github.com/serenity-rs/serenity/tree/current/examples
* https://docs.rs/serenity/0.6.3/serenity/client/index.html
* https://docs.rs/serenity/0.6.3/serenity/framework/index.html

Tasks:
* [ ] `serenity` 0.6
* [ ] `randomize` 3.0
* [ ] Probably want some CI
* [ ] Might as well add bors